### PR TITLE
Lpodgajny/cmd 94 wydluzenie podgladu notatki

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,129 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is **Notary Vue** - a Vue 3 application built with Vite, TypeScript, and TailwindCSS following TDD principles. It's a simple note display application designed as a learning project for Test-Driven Development and CI/CD practices.
+
+## Essential Commands
+
+### Development
+
+```bash
+npm run dev          # Development server (port 5173)
+npm run build        # Production build (includes TypeScript compilation)
+npm run preview      # Preview production build
+```
+
+### Testing & Quality Assurance
+
+```bash
+npm run test         # Unit tests in watch mode (Vitest)
+npm run test:run     # Unit tests single run
+npm run test:ui      # Unit tests with UI interface
+npm run test:coverage # Unit tests with coverage report
+npm run lint         # TypeScript type checking
+npm run lint:fix     # Code formatting with Prettier
+```
+
+**Important**: Always run `npm run lint` and `npm run test:run` after making changes. These commands are enforced by CI/CD pipeline.
+
+## Architecture & Code Structure
+
+### Component Architecture
+
+- **App.vue**: Root component that renders NoteDisplay
+- **NoteDisplay.vue**: Main feature component displaying static note content
+- Components follow Vue 3 Composition API with `<script setup>`
+- All styling uses TailwindCSS utility classes
+
+### Test Strategy
+
+- **Unit tests**: Located in `__tests__/` directories alongside components
+- **Test naming**: Use Polish descriptions starting with "powinien" (should)
+- **Snapshot tests**: Included to track component structure changes
+- **TDD approach**: Write failing tests first, then implement features
+
+### TypeScript Configuration
+
+- Strict mode enabled with `noUnusedLocals` and `noUnusedParameters`
+- Path alias `@/*` maps to `./src/*`
+- Vue 3 specific configuration with JSX preserve mode
+
+### Styling System (from .cursorrules)
+
+- **Primary**: TailwindCSS for all styling
+- **Component library**: shadcn-vue components (when added)
+- **Naming**: UI components have `Ui` prefix (UiButton, UiCard)
+- **Class ordering**: Enforced by prettier-plugin-tailwindcss
+- **Responsive**: Mobile-first approach with max 2 breakpoints per component
+- **Limits**: Max 10 classes per element, max 3 nesting levels
+
+### Build & Deployment
+
+- **Build tool**: Vite with Vue plugin
+- **Deployment**: Automated via Vercel on main branch
+- **Bundle size limit**: 2MB (enforced by CI)
+- **Node version**: 20.x LTS
+
+## CI/CD Pipeline
+
+### Automated Checks (on PR)
+
+1. TypeScript type checking (`npm run lint`)
+2. Unit tests execution (`npm run test:run`)
+3. Build verification (`npm run build`)
+4. Bundle size validation (<2MB)
+5. Merge conflict detection
+
+### Git Hooks (Husky)
+
+- **Pre-commit**: Prettier formatting via lint-staged
+- **Files processed**: `*.{vue,ts,js,json,md}`
+
+### Branch Protection
+
+- Main branch requires PR approval
+- All CI checks must pass before merge
+- Up-to-date branch requirement enforced
+
+## Development Workflow
+
+### TDD Cycle
+
+1. **RED**: Write failing test in `__tests__/` directory
+2. **GREEN**: Implement minimal code to pass the test
+3. **REFACTOR**: Improve code while keeping tests green
+
+### Component Development
+
+- Create component in appropriate directory under `src/components/`
+- Write tests first following TDD principles
+- Use existing patterns from NoteDisplay.vue as reference
+- Follow Vue 3 Composition API with `<script setup>`
+
+### Code Quality Standards
+
+- Comments in Polish (as per .cursorrules)
+- No arbitrary Tailwind values without TODO justification
+- Extract repeated class combinations into components or @apply
+- Maintain accessibility with focus-visible states and aria attributes
+
+## Environment Setup
+
+- **Node.js**: 20.x LTS required
+- **Package manager**: npm (lock file committed)
+- **Development port**: 5173 (Vite default)
+
+## File Structure Context
+
+```
+src/
+├── components/          # Vue components
+│   ├── __tests__/      # Component tests
+│   └── NoteDisplay.vue # Main feature component
+├── assets/             # Static assets (CSS, images)
+├── views/              # Page-level components
+└── main.js            # Application entry point
+```

--- a/docs/prd-wydluzenie-podgladu-notatki.md
+++ b/docs/prd-wydluzenie-podgladu-notatki.md
@@ -1,0 +1,173 @@
+# PRD: Wydłużenie podglądu notatki (CMD-94)
+
+## Introduction/Overview
+
+Currently, the note preview in the NoteList component is limited to approximately 120 characters displayed on a single line with ellipsis. This makes it difficult to distinguish between short and long notes at a glance, and users cannot see enough context before deciding which note to interact with.
+
+This feature extends the note preview to display up to 5 lines of text with automatic wrapping, allowing users to see more content directly in the list view. This improves content scanability and helps users quickly identify the notes they're looking for.
+
+**Problem Statement:** Users cannot see enough note content in the list view to distinguish between notes effectively.
+
+**Goal:** Extend the note body preview from 1 line (~120 characters) to up to 5 lines with text wrapping.
+
+## Goals
+
+1. Display up to 5 lines of note body text in the preview
+2. Automatically wrap text to fit the container width (no horizontal scrolling)
+3. Show ellipsis (...) when content exceeds 5 lines
+4. Maintain visual consistency across all screen sizes (mobile and desktop)
+5. Allow cards to dynamically adjust height based on content length
+6. Preserve existing functionality and styling of the NoteList component
+
+## User Stories
+
+**As a** user viewing my notes list
+**I want** to see more lines of content in each note preview
+**So that** I can better distinguish between notes and understand their content without opening them
+
+**As a** user with short notes (1-2 lines)
+**I want** the preview to only show the actual content
+**So that** extra white space isn't wasted
+
+**As a** user with long notes (10+ lines)
+**I want** to see the first 5 lines with an ellipsis
+**So that** I know there's more content and can distinguish it from shorter notes
+
+## Functional Requirements
+
+1. **FR-1:** The note body preview MUST display up to 5 lines of text
+2. **FR-2:** Text MUST wrap automatically based on the container width (no horizontal overflow)
+3. **FR-3:** When note content exceeds 5 lines, an ellipsis (...) MUST be shown at the end of the 5th line
+4. **FR-4:** For notes with fewer than 5 lines of content, the preview MUST only display the actual content height (not force 5 lines of space)
+5. **FR-5:** The 120-character limit MUST be removed in favor of line-based truncation
+6. **FR-6:** The preview line count MUST remain consistent at 5 lines across all responsive breakpoints (mobile, tablet, desktop)
+7. **FR-7:** Card height MUST dynamically adjust based on preview content length (taller for longer notes)
+8. **FR-8:** All existing styling (typography, spacing, colors) MUST be preserved
+9. **FR-9:** The implementation MUST use CSS `line-clamp` with `overflow: hidden` for line truncation
+10. **FR-10:** Existing tests for NoteList component MUST continue to pass
+
+## Non-Goals (Out of Scope)
+
+1. Adding a "Read more" link or button (no detail view exists yet - see CMD-93)
+2. Making the preview clickable or interactive (separate feature)
+3. Adding animation or transitions for expanding/collapsing
+4. Implementing adaptive line counts per breakpoint (e.g., 3 lines on mobile, 5 on desktop)
+5. Changing the note card layout, colors, or typography beyond the preview text
+6. Showing line numbers or additional metadata
+7. Implementing rich text formatting or markdown rendering in preview
+
+## Design Considerations
+
+### Current Implementation
+
+- Note body preview shows first ~120 characters
+- Single line display with `overflow: hidden` and `text-overflow: ellipsis`
+- Located in `NoteList.vue` component
+
+### Proposed Changes
+
+- Replace character-based truncation with line-based truncation
+- Use CSS properties:
+  ```css
+  display: -webkit-box;
+  -webkit-line-clamp: 5;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  word-wrap: break-word;
+  ```
+- Maintain existing Tailwind utility classes for consistency
+
+### Visual Examples
+
+**Short note (2 lines):**
+
+```
+Title: Shopping List
+Body:
+Milk
+Eggs
+```
+
+→ Shows 2 lines, card height adjusts accordingly
+
+**Long note (10 lines):**
+
+```
+Title: Meeting Notes
+Body:
+Discussed Q4 roadmap with the team.
+Key decisions: prioritize feature X,
+defer feature Y to Q1 next year.
+Action items: John to follow up with
+design team, Sarah to update the...
+```
+
+→ Shows exactly 5 lines with ellipsis at end
+
+### Responsive Behavior
+
+- **Mobile (< 768px):** 5 lines
+- **Tablet (768px - 1024px):** 5 lines
+- **Desktop (> 1024px):** 5 lines
+- Text wraps naturally based on container width at each breakpoint
+
+## Technical Considerations
+
+1. **Browser Support:** CSS `line-clamp` is well-supported in modern browsers (Chrome, Firefox, Safari, Edge)
+2. **Fallback:** For older browsers, use standard `overflow: hidden` without line-clamp
+3. **Testing:** Update existing snapshot tests to accommodate multi-line previews
+4. **Component Location:** Changes confined to `NoteList.vue` component
+5. **No Store Changes:** No modifications needed to Pinia store or data model
+6. **Performance:** Line-clamp is performant; no JavaScript truncation logic needed
+7. **Accessibility:** Ensure truncated text doesn't break screen reader functionality
+
+### Dependencies
+
+- None (self-contained change to NoteList component)
+
+### Files to Modify
+
+- `src/components/NoteList.vue` - Update body preview styling
+- `src/components/__tests__/NoteList.spec.ts` - Update tests for multi-line preview
+
+## Success Metrics
+
+### Functional Success Criteria
+
+1. **Verification:** Create 3 test notes:
+   - Short note (1-2 lines): "Buy milk"
+   - Medium note (3-4 lines): 50-80 words
+   - Long note (10+ lines): 200+ words
+2. **Expected Results:**
+   - Short note: Shows actual content, no ellipsis, smaller card
+   - Medium note: Shows full content, no ellipsis, medium card
+   - Long note: Shows exactly 5 lines with ellipsis, taller card
+3. **Visual Consistency:** Cards maintain consistent styling (fonts, colors, spacing)
+4. **Responsive:** Behavior consistent across mobile, tablet, desktop viewports
+5. **Tests:** All existing NoteList tests pass (update snapshots as needed)
+
+### Qualitative Success
+
+- Users can visually distinguish short notes from long notes at a glance
+- List view provides more context without requiring note detail view
+- No regression in loading performance or visual appearance
+
+## Open Questions
+
+1. **Future Consideration:** Should we add a visual indicator (like a "..." badge) to show there's more content beyond the preview? (Defer to later feature)
+2. **Edge Case:** How should we handle notes with very long single words (e.g., URLs)? Current approach with `word-wrap: break-word` will break mid-word - is this acceptable?
+3. **Testing:** Do we need visual regression tests or are unit/snapshot tests sufficient?
+
+---
+
+## Related Issues
+
+- **Depends on:** None
+- **Blocks:** CMD-93 (note detail view will eventually replace/complement this preview)
+- **Related:** CMD-96, CMD-95 (editing/deletion will work with this improved preview)
+
+## Timeline
+
+- **Estimated Effort:** 2-4 hours (small improvement)
+- **Complexity:** Low
+- **Priority:** Medium (quick win, improves UX)

--- a/src/components/NoteList.vue
+++ b/src/components/NoteList.vue
@@ -26,13 +26,6 @@ const formatUpdatedAt = (timestamp: number) =>
     hour: "2-digit",
     minute: "2-digit",
   });
-
-const getBodyPreview = (body: string) => {
-  if (!body) return "";
-
-  const preview = body.slice(0, 120);
-  return body.length > 120 ? `${preview}…` : preview;
-};
 </script>
 
 <template>
@@ -61,8 +54,8 @@ const getBodyPreview = (body: string) => {
             {{ formatUpdatedAt(note.updatedAt) }}
           </time>
         </header>
-        <p v-if="note.body" class="mt-2 text-sm text-slate-600">
-          {{ getBodyPreview(note.body) }}
+        <p v-if="note.body" class="mt-2 line-clamp-5 text-sm text-slate-600">
+          {{ note.body }}
         </p>
         <p v-else class="mt-2 text-sm text-slate-400">No body text yet.</p>
       </li>

--- a/src/components/NoteList.vue
+++ b/src/components/NoteList.vue
@@ -54,7 +54,10 @@ const formatUpdatedAt = (timestamp: number) =>
             {{ formatUpdatedAt(note.updatedAt) }}
           </time>
         </header>
-        <p v-if="note.body" class="mt-2 line-clamp-5 text-sm text-slate-600">
+        <p
+          v-if="note.body"
+          class="mt-2 break-words line-clamp-5 text-sm text-slate-600"
+        >
           {{ note.body }}
         </p>
         <p v-else class="mt-2 text-sm text-slate-400">No body text yet.</p>

--- a/src/components/__tests__/NoteList.spec.ts
+++ b/src/components/__tests__/NoteList.spec.ts
@@ -117,13 +117,24 @@ describe("NoteList", () => {
     );
   });
 
-  it("powinien wyświetlać skróconą treść gdy jest długa", () => {
-    // Arrange
-    const longBody =
-      "This is a very long body content that should be truncated because it exceeds the maximum length of 120 characters and should show an ellipsis at the end to indicate there is more content";
+  it("powinien wyświetlać maksymalnie 5 linii tekstu dla długich notatek", () => {
+    // Arrange - tworzenie notatki z 10+ liniami tekstu
+    const longMultilineBody = [
+      "First line of the note content",
+      "Second line with more information",
+      "Third line continues the story",
+      "Fourth line adds more details",
+      "Fifth line is still visible",
+      "Sixth line should be hidden",
+      "Seventh line is also hidden",
+      "Eighth line not visible",
+      "Ninth line truncated away",
+      "Tenth line completely hidden",
+    ].join("\n");
+
     const note = createMockNote({
-      title: "Long Note",
-      body: longBody,
+      title: "Long Multiline Note",
+      body: longMultilineBody,
     });
 
     // Act
@@ -133,10 +144,9 @@ describe("NoteList", () => {
       },
     });
 
-    // Assert
-    const bodyText = wrapper.find(".text-slate-600").text();
-    expect(bodyText).toHaveLength(121); // 120 chars + ellipsis
-    expect(bodyText.endsWith("…")).toBe(true);
+    // Assert - sprawdzenie czy element ma klasę line-clamp
+    const bodyElement = wrapper.find(".text-slate-600");
+    expect(bodyElement.classes()).toContain("line-clamp-5");
   });
 
   it("powinien wyświetlać pełną treść gdy jest krótka", () => {

--- a/src/components/__tests__/NoteList.spec.ts
+++ b/src/components/__tests__/NoteList.spec.ts
@@ -118,23 +118,13 @@ describe("NoteList", () => {
   });
 
   it("powinien wyświetlać maksymalnie 5 linii tekstu dla długich notatek", () => {
-    // Arrange - tworzenie notatki z 10+ liniami tekstu
-    const longMultilineBody = [
-      "First line of the note content",
-      "Second line with more information",
-      "Third line continues the story",
-      "Fourth line adds more details",
-      "Fifth line is still visible",
-      "Sixth line should be hidden",
-      "Seventh line is also hidden",
-      "Eighth line not visible",
-      "Ninth line truncated away",
-      "Tenth line completely hidden",
-    ].join("\n");
+    // Arrange - tworzenie notatki z długą treścią (200+ słów, która na pewno przekroczy 5 linii)
+    const longBody =
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.";
 
     const note = createMockNote({
       title: "Long Multiline Note",
-      body: longMultilineBody,
+      body: longBody,
     });
 
     // Act
@@ -146,6 +136,52 @@ describe("NoteList", () => {
 
     // Assert - sprawdzenie czy element ma klasę line-clamp
     const bodyElement = wrapper.find(".text-slate-600");
+    expect(bodyElement.classes()).toContain("line-clamp-5");
+    expect(bodyElement.classes()).toContain("break-words");
+  });
+
+  it("powinien mieć break-words dla krótkiej notatki", () => {
+    // Arrange - krótka notatka (20-30 słów, 1-2 linie)
+    const shortBody =
+      "This is a short note with just a few words that should display normally without any truncation issues.";
+
+    const note = createMockNote({
+      title: "Short Note",
+      body: shortBody,
+    });
+
+    // Act
+    const wrapper = mount(NoteList, {
+      props: {
+        notes: [note],
+      },
+    });
+
+    // Assert - nawet krótkie notatki powinny mieć obie klasy
+    const bodyElement = wrapper.find(".text-slate-600");
+    expect(bodyElement.classes()).toContain("line-clamp-5");
+    expect(bodyElement.classes()).toContain("break-words");
+  });
+
+  it("powinien łamać bardzo długie nierozdzielne ciągi znaków", () => {
+    // Arrange - notatka z bardzo długim słowem bez spacji (symulacja buga z "Dłuuuuuuu...")
+    const unbreakableString = "Dł" + "u".repeat(500) + "ga notatka";
+
+    const note = createMockNote({
+      title: "Unbreakable String Note",
+      body: unbreakableString,
+    });
+
+    // Act
+    const wrapper = mount(NoteList, {
+      props: {
+        notes: [note],
+      },
+    });
+
+    // Assert - break-words musi być obecny, aby zapobiec poziomemu przepełnieniu
+    const bodyElement = wrapper.find(".text-slate-600");
+    expect(bodyElement.classes()).toContain("break-words");
     expect(bodyElement.classes()).toContain("line-clamp-5");
   });
 

--- a/tasks/tasks-prd-wydluzenie-podgladu-notatki.md
+++ b/tasks/tasks-prd-wydluzenie-podgladu-notatki.md
@@ -1,0 +1,84 @@
+# Tasks: Wydłużenie podglądu notatki (CMD-94)
+
+## Relevant Files
+
+- `src/components/NoteList.vue` - Main component containing note preview display logic and styling
+- `src/components/__tests__/NoteList.spec.ts` - Unit tests for NoteList component
+
+### Notes
+
+- Unit tests should typically be placed alongside the code files they are testing (e.g., `MyComponent.tsx` and `MyComponent.test.tsx` in the same directory).
+- Use `npm run test` to run tests in watch mode, or `npm run test:run` for a single test run.
+- Use `npm run lint` for TypeScript type checking after making changes.
+
+## Tasks
+
+### RED Phase - Write Failing Tests
+
+- [ ] 1.0 Add test case for long notes (10+ lines) - verify 5-line truncation with ellipsis
+  - [ ] 1.1 Open `src/components/__tests__/NoteList.spec.ts`
+  - [ ] 1.2 Create a new test case after the existing truncation tests (around line 141)
+  - [ ] 1.3 Name the test "powinien wyświetlać maksymalnie 5 linii tekstu dla długich notatek"
+  - [ ] 1.4 Create a mock note with body containing 10+ lines of text (each line should be short enough to not wrap on most screens, e.g., 30-40 characters per line)
+  - [ ] 1.5 Mount the NoteList component with this long note
+  - [ ] 1.6 Query the body preview element using `.text-slate-600` selector
+  - [ ] 1.7 Add assertion to check that the element has CSS classes for line-clamp: expect element to have classes containing `line-clamp` or check computed styles
+  - [ ] 1.8 Run `npm run test:run` to verify the test fails (it should fail because line-clamp is not implemented yet)
+
+- [ ] 2.0 Update existing test for body preview truncation to expect line-based behavior instead of character-based
+  - [ ] 2.1 Locate the test "powinien wyświetlać skróconą treść gdy jest długa" (line 120)
+  - [ ] 2.2 Remove or comment out the assertion that checks for exactly 121 characters: `expect(bodyText).toHaveLength(121);`
+  - [ ] 2.3 Keep the test for ellipsis presence: `expect(bodyText.endsWith("…")).toBe(true);`
+  - [ ] 2.4 Update the test body text to be multi-line (10+ short lines) instead of one long line
+  - [ ] 2.5 Add a comment explaining that truncation is now CSS-based (line-clamp) rather than character-based
+  - [ ] 2.6 Run `npm run test:run` to see if the test still fails (expected, as implementation is not done)
+
+### GREEN Phase - Implement to Pass Tests
+
+- [ ] 3.0 Remove getBodyPreview() function that performs character-based truncation
+  - [ ] 3.1 Open `src/components/NoteList.vue`
+  - [ ] 3.2 Locate the `getBodyPreview` function (lines 30-35)
+  - [ ] 3.3 Delete the entire `getBodyPreview` function
+  - [ ] 3.4 Save the file
+
+- [ ] 4.0 Update template to remove getBodyPreview() call and display note.body directly
+  - [ ] 4.1 In `src/components/NoteList.vue`, locate the template section where body preview is rendered (line 64-65)
+  - [ ] 4.2 Change `{{ getBodyPreview(note.body) }}` to `{{ note.body }}`
+  - [ ] 4.3 Save the file
+
+- [ ] 5.0 Add CSS classes to body preview paragraph for line-clamp styling
+  - [ ] 5.1 In the template section of `src/components/NoteList.vue`, find the `<p>` tag that displays note.body (line 64)
+  - [ ] 5.2 Update the class attribute from `class="mt-2 text-sm text-slate-600"` to include line-clamp utilities
+  - [ ] 5.3 Add the following Tailwind classes: `line-clamp-5` (this is a built-in Tailwind utility)
+  - [ ] 5.4 Final classes should be: `class="mt-2 text-sm text-slate-600 line-clamp-5"`
+  - [ ] 5.5 Save the file
+  - [ ] 5.6 Run `npm run test:run` to check if tests pass
+
+### REFACTOR Phase - Verify and Clean Up
+
+- [ ] 6.0 Run all tests and verify they pass
+  - [ ] 6.1 Execute `npm run test:run` in the terminal
+  - [ ] 6.2 Verify all tests pass, especially the updated truncation tests
+  - [ ] 6.3 If any tests fail, review the error messages and fix accordingly
+  - [ ] 6.4 Update snapshot tests if prompted (`npm run test:run -- -u`)
+
+- [ ] 7.0 Run type checking
+  - [ ] 7.1 Execute `npm run lint` in the terminal
+  - [ ] 7.2 Verify no TypeScript errors are reported
+  - [ ] 7.3 Fix any type errors if they appear (none expected for this change)
+
+- [ ] 8.0 Manual verification with different note lengths in browser
+  - [ ] 8.1 Start the development server: `npm run dev`
+  - [ ] 8.2 Open the app in browser (http://localhost:5173)
+  - [ ] 8.3 Create or view a note with 1-2 lines of text - verify it displays fully without ellipsis
+  - [ ] 8.4 Create or view a note with 3-4 lines of text - verify it displays fully without ellipsis
+  - [ ] 8.5 Create or view a note with 10+ lines of text - verify only 5 lines are visible with ellipsis
+  - [ ] 8.6 Verify the card heights adjust appropriately (shorter for short notes, taller for long notes up to 5 lines)
+
+- [ ] 9.0 Verify responsive behavior on mobile, tablet, and desktop viewports
+  - [ ] 9.1 With dev server running, open browser DevTools (F12)
+  - [ ] 9.2 Switch to responsive design mode (Ctrl+Shift+M or Cmd+Shift+M)
+  - [ ] 9.3 Test at mobile width (375px) - verify 5-line truncation still works and text wraps properly
+  - [ ] 9.4 Test at tablet width (768px) - verify 5-line truncation and text wrapping
+  - [ ] 9.5 Test at desktop width (1440px) - verify 5-line truncation and text wrapping
+  - [ ] 9.6 Verify no horizontal scrolling occurs at any breakpoint


### PR DESCRIPTION
Wydłużyłem podgląd notatki tak, aby było widać maksymalnie do 5 linii tekstu. Jeśli jest mniej, to mniej. 

Przy okazji natknąłem się na buga, gdzie przy długich, nieprzerwanych stringach tekst nie załamywał się do nowej linii i wychodził poza box i nie było go widać (tak mogą się na przykład zachowywać długie URLe). Dodałem `break-word`, aby wyświetlało się poprawnie.