### PR TITLE
feat: Add collapsible tool sidebar on the right (cmd-108)

### DIFF
--- a/src/components/ToolSidebar.vue
+++ b/src/components/ToolSidebar.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts"></script>
+
+<template>
+  <div class="flex h-full flex-col overflow-y-auto">
+    <header class="flex items-center gap-2 border-b border-slate-200 p-4">
+      <!-- Header area for future tool buttons -->
+    </header>
+    <div class="flex-1 overflow-y-auto p-4">
+      <p class="text-sm text-slate-600">
+        Tools will be available here in the future.
+      </p>
+    </div>
+  </div>
+</template>

--- a/src/components/__tests__/ToolSidebar.spec.ts
+++ b/src/components/__tests__/ToolSidebar.spec.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import ToolSidebar from "../ToolSidebar.vue";
+
+describe("ToolSidebar", () => {
+  it("should render a header section at the top", () => {
+    // Act
+    const wrapper = mount(ToolSidebar);
+
+    // Assert
+    const header = wrapper.find("header");
+    expect(header.exists()).toBe(true);
+  });
+
+  it("should have header visible when component is rendered", () => {
+    // Act
+    const wrapper = mount(ToolSidebar);
+
+    // Assert
+    const header = wrapper.find("header");
+    expect(header.exists()).toBe(true);
+    expect(header.isVisible()).toBe(true);
+  });
+
+  it("should have flex layout structure similar to NoteList", () => {
+    // Act
+    const wrapper = mount(ToolSidebar);
+
+    // Assert - should have flex column layout
+    const root = wrapper.find("div");
+    expect(root.classes()).toContain("flex");
+    expect(root.classes()).toContain("flex-col");
+  });
+
+  it("should have content area for future tools", () => {
+    // Act
+    const wrapper = mount(ToolSidebar);
+
+    // Assert - should have a content area (div with flex-1 or similar)
+    const contentArea = wrapper.find(".flex-1");
+    expect(contentArea.exists()).toBe(true);
+  });
+
+  it("should display placeholder text in content area", () => {
+    // Act
+    const wrapper = mount(ToolSidebar);
+
+    // Assert - should have placeholder text indicating future tools
+    const contentArea = wrapper.find(".flex-1");
+    expect(contentArea.text()).toBeTruthy();
+  });
+});

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -2,6 +2,7 @@
 import { computed, onMounted, ref } from "vue";
 import NoteEditor from "../components/NoteEditor.vue";
 import NoteList from "../components/NoteList.vue";
+import ToolSidebar from "../components/ToolSidebar.vue";
 import {
   NoteStoreError,
   useNotesStore,
@@ -12,6 +13,7 @@ const notesStore = useNotesStore();
 const loadErrorMessage = ref("");
 const currentNote = ref<Note | null>(null);
 const isSidebarCollapsed = ref(false);
+const isToolSidebarCollapsed = ref(false);
 const noteEditorRef = ref<InstanceType<typeof NoteEditor> | null>(null);
 
 // Load sidebar state from localStorage on mount
@@ -20,6 +22,10 @@ onMounted(() => {
   const savedState = localStorage.getItem("sidebarCollapsed");
   if (savedState !== null) {
     isSidebarCollapsed.value = savedState === "true";
+  }
+  const savedToolSidebarState = localStorage.getItem("toolSidebarCollapsed");
+  if (savedToolSidebarState !== null) {
+    isToolSidebarCollapsed.value = savedToolSidebarState === "true";
   }
 });
 
@@ -80,6 +86,14 @@ const handleNewNote = () => {
 const toggleSidebar = () => {
   isSidebarCollapsed.value = !isSidebarCollapsed.value;
   localStorage.setItem("sidebarCollapsed", isSidebarCollapsed.value.toString());
+};
+
+const toggleToolSidebar = () => {
+  isToolSidebarCollapsed.value = !isToolSidebarCollapsed.value;
+  localStorage.setItem(
+    "toolSidebarCollapsed",
+    isToolSidebarCollapsed.value.toString()
+  );
 };
 
 const handleSaveClick = async () => {
@@ -178,5 +192,55 @@ const isSaving = computed(() => {
         />
       </div>
     </section>
+    <aside
+      class="relative border-l border-slate-200 bg-white transition-all duration-300"
+      :class="isToolSidebarCollapsed ? 'w-0 overflow-hidden' : 'w-96'"
+    >
+      <ToolSidebar />
+      <button
+        v-if="!isToolSidebarCollapsed"
+        type="button"
+        class="absolute left-0 top-4 z-10 flex h-8 w-8 items-center justify-center rounded-r-md border border-l-0 border-slate-200 bg-white text-slate-600 transition hover:bg-slate-50"
+        aria-label="Collapse tool sidebar"
+        @click="toggleToolSidebar"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          class="h-4 w-4"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M9 5l7 7-7 7"
+          />
+        </svg>
+      </button>
+    </aside>
+    <button
+      v-if="isToolSidebarCollapsed"
+      type="button"
+      class="absolute right-0 top-4 z-10 flex h-6 w-6 items-center justify-center rounded-l-md border border-r-0 border-slate-200 bg-white text-slate-600 transition hover:bg-slate-50"
+      aria-label="Expand tool sidebar"
+      @click="toggleToolSidebar"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        class="h-3.5 w-3.5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M15 19l-7-7 7-7"
+        />
+      </svg>
+    </button>
   </main>
 </template>

--- a/src/views/__tests__/HomeView.spec.ts
+++ b/src/views/__tests__/HomeView.spec.ts
@@ -316,4 +316,173 @@ describe("HomeView", () => {
     expect(saveButton).toBeDefined();
     expect(saveButton?.exists()).toBe(true);
   });
+
+  describe("tool sidebar", () => {
+    beforeEach(() => {
+      // Clear localStorage before each test
+      localStorage.clear();
+    });
+
+    it("should render tool sidebar in layout", () => {
+      // Act
+      const wrapper = mount(HomeView);
+
+      // Assert - should have two aside elements (left sidebar and tool sidebar)
+      const sidebars = wrapper.findAll("aside");
+      expect(sidebars.length).toBe(2);
+    });
+
+    it("should render ToolSidebar component in right sidebar", () => {
+      // Act
+      const wrapper = mount(HomeView);
+
+      // Assert
+      const toolSidebar = wrapper.findComponent({ name: "ToolSidebar" });
+      expect(toolSidebar.exists()).toBe(true);
+    });
+
+    it("should default to tool sidebar expanded", () => {
+      // Act
+      const wrapper = mount(HomeView);
+
+      // Assert - tool sidebar should be visible (not collapsed)
+      const sidebars = wrapper.findAll("aside");
+      const toolSidebar = sidebars[1]; // Second aside is the tool sidebar
+      expect(toolSidebar.classes()).not.toContain("w-0");
+      expect(toolSidebar.classes()).not.toContain("hidden");
+    });
+
+    it("should have tool sidebar with w-96 width when expanded", () => {
+      // Act
+      const wrapper = mount(HomeView);
+
+      // Assert
+      const sidebars = wrapper.findAll("aside");
+      const toolSidebar = sidebars[1]; // Second aside is the tool sidebar
+      expect(toolSidebar.classes()).toContain("w-96");
+    });
+
+    it("should have tool sidebar with border-l styling", () => {
+      // Act
+      const wrapper = mount(HomeView);
+
+      // Assert
+      const sidebars = wrapper.findAll("aside");
+      const toolSidebar = sidebars[1]; // Second aside is the tool sidebar
+      expect(toolSidebar.classes()).toContain("border-l");
+    });
+
+    it("should have tool sidebar toggle button when expanded", () => {
+      // Act
+      const wrapper = mount(HomeView);
+
+      // Assert - should have toggle button for tool sidebar
+      const sidebars = wrapper.findAll("aside");
+      const toolSidebar = sidebars[1];
+      const toggleButton = toolSidebar.find(
+        'button[aria-label*="Collapse tool sidebar"]'
+      );
+      expect(toggleButton.exists()).toBe(true);
+    });
+
+    it("should toggle tool sidebar collapse state when toggle button clicked", async () => {
+      // Act
+      const wrapper = mount(HomeView);
+      const sidebars = wrapper.findAll("aside");
+      const toolSidebar = sidebars[1];
+      const initialClasses = toolSidebar.classes();
+
+      // Find toggle button in tool sidebar
+      const toggleButton = toolSidebar.find(
+        'button[aria-label*="Collapse tool sidebar"]'
+      );
+      expect(toggleButton.exists()).toBe(true);
+
+      // Click toggle
+      await toggleButton.trigger("click");
+      await wrapper.vm.$nextTick();
+
+      // Assert - tool sidebar classes should change
+      const afterClasses = wrapper.findAll("aside")[1].classes();
+      expect(afterClasses).not.toEqual(initialClasses);
+    });
+
+    it("should toggle tool sidebar independently from left sidebar", async () => {
+      // Arrange
+      const wrapper = mount(HomeView);
+      const sidebars = wrapper.findAll("aside");
+      const leftSidebar = sidebars[0];
+
+      // Act - collapse left sidebar
+      const leftToggleButton = leftSidebar.find(
+        'button[aria-label*="Collapse sidebar"]'
+      );
+      await leftToggleButton.trigger("click");
+      await wrapper.vm.$nextTick();
+
+      // Assert - tool sidebar should still be expanded
+      const toolSidebarAfter = wrapper.findAll("aside")[1];
+      expect(toolSidebarAfter.classes()).toContain("w-96");
+
+      // Act - collapse tool sidebar
+      const toolToggleButton = toolSidebarAfter.find(
+        'button[aria-label*="Collapse tool sidebar"]'
+      );
+      await toolToggleButton.trigger("click");
+      await wrapper.vm.$nextTick();
+
+      // Assert - tool sidebar should be collapsed, left sidebar should remain collapsed
+      const finalToolSidebar = wrapper.findAll("aside")[1];
+      expect(finalToolSidebar.classes()).toContain("w-0");
+      const finalLeftSidebar = wrapper.findAll("aside")[0];
+      expect(finalLeftSidebar.classes()).toContain("w-0");
+    });
+
+    it("should persist tool sidebar state in localStorage", async () => {
+      // Arrange
+      const wrapper = mount(HomeView);
+      const sidebars = wrapper.findAll("aside");
+      const toolSidebar = sidebars[1];
+
+      // Act - toggle tool sidebar
+      const toggleButton = toolSidebar.find(
+        'button[aria-label*="Collapse tool sidebar"]'
+      );
+      await toggleButton.trigger("click");
+      await wrapper.vm.$nextTick();
+
+      // Assert - localStorage should have tool sidebar state
+      const savedState = localStorage.getItem("toolSidebarCollapsed");
+      expect(savedState).toBe("true");
+    });
+
+    it("should load tool sidebar state from localStorage on mount", async () => {
+      // Arrange
+      localStorage.setItem("toolSidebarCollapsed", "true");
+
+      // Act
+      const wrapper = mount(HomeView);
+      await wrapper.vm.$nextTick();
+
+      // Assert - tool sidebar should be collapsed
+      const sidebars = wrapper.findAll("aside");
+      const toolSidebar = sidebars[1];
+      expect(toolSidebar.classes()).toContain("w-0");
+    });
+
+    it("should have tool sidebar expand button when collapsed", async () => {
+      // Arrange
+      localStorage.setItem("toolSidebarCollapsed", "true");
+
+      // Act
+      const wrapper = mount(HomeView);
+      await wrapper.vm.$nextTick();
+
+      // Assert - should have expand button for tool sidebar
+      const expandButton = wrapper.find(
+        'button[aria-label*="Expand tool sidebar"]'
+      );
+      expect(expandButton.exists()).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Overview

This PR adds a second collapsible sidebar on the right side of the application layout. The tool sidebar is completely independent from the left sidebar (notes list) and is prepared for future tools like a chat interface.

## Key Features

- **ToolSidebar Component**: New component with header area and placeholder content, ready for future tools
- **Independent State Management**: Tool sidebar has its own state and localStorage persistence (key: `toolSidebarCollapsed`)
- **Wider Width**: Tool sidebar uses `w-96` (384px) - wider than the left sidebar's `w-80` (320px)
- **Default Expanded**: Tool sidebar starts expanded by default
- **Mirrored Toggle Buttons**: Toggle buttons are positioned on the left side when expanded, right side when collapsed (mirrored from left sidebar)
- **Independent Toggle**: Tool sidebar can be toggled independently from the left sidebar

## Implementation Details

### TDD Approach
- ✅ RED: Wrote failing tests first
- ✅ GREEN: Implemented minimal code to pass tests
- ✅ REFACTOR: Cleaned up code and improved test specificity

### Files Changed
- `src/components/ToolSidebar.vue` (new)
- `src/components/__tests__/ToolSidebar.spec.ts` (new)
- `src/views/HomeView.vue` (updated)
- `src/views/__tests__/HomeView.spec.ts` (updated)

### Screenshots

Tool sidebar shown
<img width="2668" height="830" alt="image" src="https://github.com/user-attachments/assets/5abe9d2a-14b8-4d87-90f4-fb42e821d9ac" />

Tool sidebar collapsed
<img width="2672" height="692" alt="image" src="https://github.com/user-attachments/assets/90e01fb8-83e2-4cc4-9f53-728067c02fc2" />


### Testing
- All 119 tests pass ✅
- No linting errors ✅
- Comprehensive test coverage for tool sidebar functionality

## Technical Details

- Tool sidebar uses `border-l` instead of `border-r` for visual distinction
- Separate localStorage keys: `sidebarCollapsed` (left) and `toolSidebarCollapsed` (right)
- Same transition animations as left sidebar for consistency
- z-index management ensures toggle buttons appear correctly

## Future Work

The tool sidebar is now ready for future tools like:
- Chat interface for interacting with notes
- Additional utility tools

Closes cmd-108